### PR TITLE
many: various fixes/tweaks for the classic FDE work

### DIFF
--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1310,7 +1310,8 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		UnpackedGadgetDir: mntPtForType[snap.TypeGadget],
 
 		RecoverySystemLabel: systemLabel,
-		RecoverySystemDir:   systemLabel,
+		// TODO: important but a bit unclear why needed
+		RecoverySystemDir: systemLabel,
 
 		Recovery: false,
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1310,8 +1310,12 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		UnpackedGadgetDir: mntPtForType[snap.TypeGadget],
 
 		RecoverySystemLabel: systemLabel,
+		RecoverySystemDir:   systemLabel,
 
 		Recovery: false,
+
+		// XXX: rename to something more neutral like "TargetDir" ?
+		InstallHostWritableDir: filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data"),
 	}
 
 	logger.Debugf("making the installed system runnable")

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1308,7 +1308,10 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		GadgetPath: snapSeeds[snap.TypeGadget].Path,
 
 		UnpackedGadgetDir: mntPtForType[snap.TypeGadget],
-		Recovery:          false,
+
+		RecoverySystemLabel: systemLabel,
+
+		Recovery: false,
 	}
 
 	logger.Debugf("making the installed system runnable")
@@ -1316,7 +1319,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.Tomb) error {

--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
@@ -100,17 +101,19 @@ func postSystemsInstallSetupStorageEncryption(details *client.SystemDetails) err
 // XXX: reuse/extract cmd/snap/wait.go:waitMixin()
 func waitChange(chgId string) error {
 	cli := client.New(nil)
-	chg, err := cli.Change(chgId)
-	if err != nil {
-		return err
-	}
 	for {
+		chg, err := cli.Change(chgId)
+		if err != nil {
+			return err
+		}
+
 		if chg.Err != "" {
 			return errors.New(chg.Err)
 		}
 		if chg.Ready {
 			return nil
 		}
+		time.Sleep(1 * time.Second)
 	}
 }
 

--- a/tests/lib/fakeinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/fakeinstaller/mk-classic-rootfs.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# uncomment for better debug messages
+#set -x
+#exec > /tmp/mk-classic-rootfs.sh.log
+#exec 2>&1
+
 
 # XXX: merge with the work from alfonso in
 # tests/nested/manual/fde-on-classic/mk-image.sh (PR:12102)
@@ -48,6 +53,14 @@ PermitRootLogin yes
 PasswordAuthentication yes
 EOF
 
+    # install the current in-development version of snapd when available,
+    # this will give us seeding support
+    package=$(find "$GOPATH" -maxdepth 1 -name "snapd_*.deb")
+    if [ -e "$package"  ]; then
+        cp "$package" "$DESTDIR"/var/cache/apt/archives
+        sudo chroot "$DESTDIR" /usr/bin/sh -c \
+             "DEBIAN_FRONTEND=noninteractive apt install -y /var/cache/apt/archives/$(basename $package)"
+    fi
 }
 
 # get target dir from user

--- a/tests/main/classic-unencrypted-fakeinstaller/task.yaml
+++ b/tests/main/classic-unencrypted-fakeinstaller/task.yaml
@@ -25,11 +25,13 @@ execute: |
   # with a modeenv
   systemctl restart snapd
 
+  # TODO: replace with "snap prepare-image my.model" once pr#112146 landed
+  # (all seed creation code)
+
   # prepare a fake classic seed
   LABEL=20220808
   mkdir -p /var/lib/snapd/seed/systems/"$LABEL"/assertions
-  cp -a "$TESTSLIB"/assertions/developer1-22-classic-dangerous.model \
-      /var/lib/snapd/seed/systems/"$LABEL"/model
+  gendeveloper1 sign-model < "$TESTSLIB"/assertions/developer1-22-classic-dangerous.json > /var/lib/snapd/seed/systems/"$LABEL"/model
   {
       cat "$TESTSLIB"/assertions/developer1.account-key
       echo

--- a/tests/main/classic-unencrypted-fakeinstaller/task.yaml
+++ b/tests/main/classic-unencrypted-fakeinstaller/task.yaml
@@ -89,3 +89,6 @@ execute: |
   test -d /run/mnt/ubuntu-data/var/lib/snapd/seed/systems/"$LABEL"
   # rootfs is there
   test -x /run/mnt/ubuntu-data/usr/lib/systemd/systemd
+  # ensure not "ubuntu-data/system-data" is generated, this is a dir only
+  # used on core
+  not test -d /run/mnt/ubuntu-data/system-data

--- a/tests/main/classic-unencrypted-fakeinstaller/task.yaml
+++ b/tests/main/classic-unencrypted-fakeinstaller/task.yaml
@@ -41,16 +41,16 @@ execute: |
   TDIR=/var/lib/snapd/seed/snaps
   mkdir -p "$TDIR"
   # TODO: use custom pc gadget for classic instead of UC one
-  snap download --target-directory="$TDIR" --channel=22 pc
+  snap download --target-directory="$TDIR" --channel=22/edge pc
   cat "$TDIR"/pc_*.assert >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
   echo >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  snap download --target-directory="$TDIR" --channel=22 pc-kernel
+  snap download --target-directory="$TDIR" --channel=22/edge pc-kernel
   cat "$TDIR"/pc-kernel_*.assert >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
   echo >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  snap download --target-directory="$TDIR" core22
+  snap download --target-directory="$TDIR" --channel=edge core22
   cat "$TDIR"/core22_*.assert >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
   echo >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  snap download --target-directory="$TDIR" snapd
+  snap download --target-directory="$TDIR" --channel=edge snapd
   cat "$TDIR"/snapd_*.assert >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
   echo >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
 


### PR DESCRIPTION
The most important part of this is that the bootable systems is no longer put on /run/mnt/ubuntu-data/system-data which is of course wrong on a classic rootfs where it's all under /mnt/ubuntu-data without the "system-data" and "user-data" separation.