### PR TITLE
Install finish step mvo with prepare image

### DIFF
--- a/tests/main/classic-unencrypted-fakeinstaller/task.yaml
+++ b/tests/main/classic-unencrypted-fakeinstaller/task.yaml
@@ -3,18 +3,48 @@ summary: Ensure installer APIs works on unencrypted devices
 # needs a modern ubuntu
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
+environment:
+  STORE_ADDR: localhost:11028
+  STORE_DIR: $(pwd)/fake-store-blobdir
+
 prepare: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+
+  echo "Install used snaps"
+  snap install test-snapd-curl --devmode --edge
+  snap install jq --devmode --edge
+
   if [ -d /var/lib/snapd/seed ]; then
       mv /var/lib/snapd/seed /var/lib/snapd/seed.orig
   fi
+   #shellcheck source=tests/lib/store.sh
+   . "$TESTSLIB"/store.sh
+   setup_fake_store "$STORE_DIR"
 
 restore: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+
   rm -rf /var/lib/snapd/seed
   if [ -d /var/lib/snapd/seed.orig ]; then
       mv /var/lib/snapd/seed.orig /var/lib/snapd/seed
   fi
+  #shellcheck source=tests/lib/store.sh
+  . "$TESTSLIB"/store.sh
+  teardown_fake_store "$STORE_DIR"
+  rm -rf ./classic-root
 
 execute: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+
   # XXX: the code in DeviceManager.SystemAndGadgetInfo() will only work on
   # classic systems with modeenv right now (which is something we may need
   # to fix to work from the classic installer).
@@ -25,40 +55,24 @@ execute: |
   # with a modeenv
   systemctl restart snapd
 
-  # TODO: replace with "snap prepare-image my.model" once pr#112146 landed
-  # (all seed creation code)
+  echo Expose the needed assertions through the fakestore
+  cp "$TESTSLIB"/assertions/developer1.account "$STORE_DIR/asserts"
+  cp "$TESTSLIB"/assertions/developer1.account-key "$STORE_DIR/asserts"
+  cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$STORE_DIR/asserts" 
+  export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
 
-  # prepare a fake classic seed
-  LABEL=20220808
-  mkdir -p /var/lib/snapd/seed/systems/"$LABEL"/assertions
-  gendeveloper1 sign-model < "$TESTSLIB"/assertions/developer1-22-classic-dangerous.json > /var/lib/snapd/seed/systems/"$LABEL"/model
-  {
-      cat "$TESTSLIB"/assertions/developer1.account-key
-      echo
-      cat "$TESTSLIB"/assertions/developer1.account
-      echo
-      cat "$TESTSLIB"/assertions/testrootorg-store.account-key
-  } >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/model-etc
-
-  TDIR=/var/lib/snapd/seed/snaps
-  mkdir -p "$TDIR"
-  # TODO: use custom pc gadget for classic instead of UC one
-  snap download --target-directory="$TDIR" --channel=22/edge pc
-  cat "$TDIR"/pc_*.assert >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  echo >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  snap download --target-directory="$TDIR" --channel=22/edge pc-kernel
-  cat "$TDIR"/pc-kernel_*.assert >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  echo >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  snap download --target-directory="$TDIR" --channel=edge core22
-  cat "$TDIR"/core22_*.assert >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  echo >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  snap download --target-directory="$TDIR" --channel=edge snapd
-  cat "$TDIR"/snapd_*.assert >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
-  echo >> /var/lib/snapd/seed/systems/"$LABEL"/assertions/snaps
+  # prepare a classic seed
+  # TODO:
+  # - create pc-classic custom gadget
+  # - kernel with updated initrd
+  # - repacked snapd snap
+  # (should be as simple as addinga "--snap=./local-gadget.snap ...")
+  LABEL="$(date +%Y%m%d)"
+  gendeveloper1 sign-model < "$TESTSLIB"/assertions/developer1-22-classic-dangerous.json > my.model
+  snap prepare-image --classic --channel=edge my.model ./classic-seed
+  cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
 
   # do some light checking that the system is valid
-  snap install test-snapd-curl --devmode --edge
-  snap install jq --devmode --edge
   test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
   test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/"$LABEL" > system
   jq '.result.model.distribution' system | MATCH "ubuntu"
@@ -92,5 +106,13 @@ execute: |
   # rootfs is there
   test -x /run/mnt/ubuntu-data/usr/lib/systemd/systemd
   # ensure not "ubuntu-data/system-data" is generated, this is a dir only
-  # used on core
+  # used on core and should not be there on classic
   not test -d /run/mnt/ubuntu-data/system-data
+  # and the boot assets are in the right place
+  test -e /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi
+  test -e /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv
+  test -e /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+  # and we have a modenv in the image
+  MATCH "mode=run" < /run/mnt/ubuntu-data/var/lib/snapd/modeenv
+  MATCH "recovery_system=$LABEL" < /run/mnt/ubuntu-data/var/lib/snapd/modeenv
+  MATCH "classic=true" < /run/mnt/ubuntu-data/var/lib/snapd/modeenv


### PR DESCRIPTION
This contains the content of https://github.com/alfonsosanchezbeato/snapd/pull/2 but it also merges master and converts the classic-unencrypted-fakeinstaller test to use `snap prepare-image` for the generation of the seed (see https://github.com/alfonsosanchezbeato/snapd/commit/8da55964d04e40916b21812f7ab884fc7762c2de)