### PR TITLE
boot,devicestate: remove no used BootWith parameter

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -51,12 +51,6 @@ type BootableSet struct {
 
 	// Recover is set when making the recovery partition bootable.
 	Recovery bool
-
-	// XXX:
-	// InstallHostWritableDir is different on
-	// classic /run/mnt/ubuntu-data vs
-	// core    /run/mnt/ubuntu-data/system-data
-	InstallHostWritableDir string
 }
 
 // MakeBootableImage sets up the given bootable set and target filesystem

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1319,9 +1319,6 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		RecoverySystemDir: systemLabel,
 
 		Recovery: true,
-
-		// XXX: rename to something more neutral like "TargetDir" ?
-		InstallHostWritableDir: filepath.Join(boot.InitramfsRunMntDir, "ubuntu-data"),
 	}
 
 	// install the bootloader configuration from the gadget


### PR DESCRIPTION
Tiny PR, I checked and the spread test still works with this. Given the recent discussion with Samuele we may need something like this back but today it's unused.